### PR TITLE
refactor and added functionality to remove tags

### DIFF
--- a/src/components/Posts/PostForm.js
+++ b/src/components/Posts/PostForm.js
@@ -67,9 +67,7 @@ export const PostForm = (props) => {
             
         })
     }       
-
-    console.log(stateTagIDArr, "IDs")
-    console.log(stateTagObjArr, "OBJ")
+    
 return (
     <>
     <h2>hey</h2>

--- a/src/components/Posts/PostForm.js
+++ b/src/components/Posts/PostForm.js
@@ -9,30 +9,35 @@ export const PostForm = (props) => {
     const {post, setPost, addPost} = useContext(PostContext)
     const { categories, getCategories} = useContext(CategoryContext)
     const {tag, tags, getTags} = useContext(TagContext)
-    const {getTagPosts, createTagPost} = useContext(TagPostContext)
-    const [stateTagIDArr] = useState([])
+    const {createTagPost} = useContext(TagPostContext)
+    const [stateTagIDArr, setTagIDArr] = useState([])
     const [stateTagObjArr, setTagObjArr] = useState([])
-
-    const tagSelect = useRef()
 
     useEffect(() => {
         getCategories()
         getTags()
-        getTagPosts()
-    },[])
+    },[]) 
 
-    const doneAddingTags = () => {
-        const currentTags = stateTagIDArr.map(t => {
-           return tags.find(tag => tag.id === t)
-       })
-       setTagObjArr(currentTags)
-    }   
- 
+    useEffect(() => {
+        const stateCopyObj = stateTagObjArr.slice()
+        const tagItems = stateTagIDArr.map(t => {
+            return tags.find(tag => tag.id === t)
+        })
+        stateCopyObj.push(tagItems)
+        setTagObjArr(stateCopyObj)
+    },[stateTagIDArr])
 
     const handleControlledInputChange = (browserEvent) => {
         const newPost = Object.assign({}, post)          
         newPost[browserEvent.target.name] = browserEvent.target.value 
         setPost(newPost)                                 
+    }
+
+    const handleTags = (browserEvent) => {  
+        const stateCopyID = stateTagIDArr.slice()
+        let newTagItem = parseInt(browserEvent.target.value)
+         stateCopyID.push(newTagItem)
+        setTagIDArr(stateCopyID)    
     }
 
     const constructPost = (evt) => {
@@ -63,6 +68,8 @@ export const PostForm = (props) => {
         })
     }       
 
+    console.log(stateTagIDArr, "IDs")
+    console.log(stateTagObjArr, "OBJ")
 return (
     <>
     <h2>hey</h2>
@@ -100,7 +107,7 @@ return (
                 <div className="form-group">
                     <label htmlFor="status">Tags: </label>
                     <select name="id" value={tag.id} className="form-control" 
-                            ref={tagSelect} >
+                            onChange={handleTags} >
                                 <option value="0">add some tags...</option>
                                 {
                                     tags.map(t => {
@@ -108,20 +115,21 @@ return (
                                     })
                                 }
                     </select>
-                    <button onClick={(evt)=> {
-                        evt.preventDefault()
-                        stateTagIDArr.push(parseInt(tagSelect.current.value))
-                        console.log(stateTagIDArr, "in onClick")
-                        }}>add tag</button>
-                    <button onClick={(evt) => {
-                        evt.preventDefault()
-                        doneAddingTags()
-                    }}>done adding tags</button>
                 </div>
             </fieldset>
             <div>
-                { stateTagObjArr.map(t => {
-                return <p>{t.tag}</p>
+                { stateTagIDArr.length === 0 ? "" : 
+                stateTagIDArr.map(t => {
+                    const tagObj = tags.find(tag => tag.id === t)
+                return <div>{tagObj.tag}
+                <button onClick={(evt) =>{
+                    evt.preventDefault()
+                    const arrCopyID = stateTagIDArr.slice()
+                    const index = arrCopyID.indexOf(tagObj.id)
+                    arrCopyID.splice(index, 1)
+                    setTagIDArr(arrCopyID)  
+                }}>x</button>
+                </div>
                 })
                 }
             </div>


### PR DESCRIPTION
refactored PostForm
​
## Description
Originally tags were being added through a useRef situation but I wanted to handle it through state and this removes the need for having an "add tag" and "done adding tags" button. If the user accidentally chooses the wrong tag they can delete before they submit the form.
​
## How do I access this branch?
```git checkout main```
```git fetch --all```
```git checkout eh-post-details```

*make sure your backend is running since this PR does not have a partner back-end PR*
​
## Motivation and Context
having an "add tag" and "done adding tags" was not the UX we were hoping to have but I needed to push up code so teammates could have View Post and Create Post functionality to work off of.
​
## How Has This Been Tested?
- console.logs() to make sure I was manipulating the data I wanted to manipulate it
- console.logs to keep track of state changes
- selecting several tags before post creation
- de-selecting at least one tag before creating the post to make sure there wasn't a TagPost object for the de-selected tag

​
## Types of changes
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
​
## Checklist:
- [ x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.